### PR TITLE
Remove non-spec-compliant comma-separated string interpretation of main

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -115,7 +115,7 @@ function validate(json) {
 
 function normalize(json) {
     if (typeof json.main === 'string') {
-        json.main = json.main.split(',');
+        json.main = [json.main];
     }
 
     // TODO


### PR DESCRIPTION
This comma-separated list interpretation of a String `main` is not specified in [the `bower.json` spec](https://github.com/bower/bower.json-spec/#main).
CC: @desandro 