### PR TITLE
test validation against all registred packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-simple-mocha": "^0.4.0",
     "mocha": "*",
+    "request": "^2.64.0",
     "underscore.string": "^3.0.3"
   },
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -357,6 +357,8 @@ describe('packages from bower registry', function () {
             }
 
             try {
+                // bypass description checks
+                package.description = '';
                 bowerJson.validate(package);
             } catch(e) {
                 invalidPackageCount++;

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ var path = require('path');
 var expect = require('expect.js');
 var _s = require('underscore.string');
 var bowerJson = require('../lib/json');
+var request = require('request');
 
 describe('.find', function () {
     it('should find the bower.json file', function (done) {
@@ -316,3 +317,59 @@ describe('.normalize', function () {
         expect(json.main).to.eql(['foo.js']);
     });
 });
+
+describe('packages from bower registry', function () {
+
+    var packageList,
+        packageListUrl = 'https://bower-component-list.herokuapp.com/';
+        
+    this.timeout(60000);
+
+    it('can be downloaded from online source ' + packageListUrl, function(done) {
+        request({
+            url: packageListUrl,
+            json: true
+        }, function(error, response, body) {
+            
+            if(error) {
+                throw error;
+            }
+
+            expect(body).to.be.an('array');
+            expect(body).to.not.be.empty;
+            packageList = body;
+
+            done();
+
+        });
+    });
+
+    it('should validate each listed package', function (done) {
+
+        expect(packageList).to.be.an('array');
+
+        var invalidPackageCount = 0;
+
+        packageList.forEach(function(package) {
+
+            if(package.name.indexOf('10digit')===0) {
+                return;
+            }
+
+            try {
+                bowerJson.validate(package);
+            } catch(e) {
+                invalidPackageCount++;
+                console.error('validation of "' + package.name + '" failed: ' + e.message);
+            }
+
+        });
+
+        if(invalidPackageCount) {
+            throw new Error(invalidPackageCount + '/' + packageList.length + ' package names do not validate');
+        }
+        done();
+
+    });
+});
+


### PR DESCRIPTION
Runs `validate()` against all packages from the registry and throws error when one or more packages do not validate. All failed validations print the reason to stderr.

JSON-Source: https://bower-component-list.herokuapp.com/